### PR TITLE
Add SkillRouter: self-contained MCP module for dynamic skill routing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,8 @@ data/eval_core/hard/
 .DS_Store
 Thumbs.db
 .omx/
+
+# Source paper (author's local files, not part of benchmark repo)
+paper/
+sections/
+figures/

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ numpy
 tqdm
 sentencepiece
 safetensors
+pyyaml
+mcp

--- a/skill-router/SKILL.md
+++ b/skill-router/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: skill-router
+description: Dynamic skill discovery and routing via Bi-Encoder + Cross-Encoder. Self-contained deployment under ~/.merged_skills/skill-router/.
+---
+
+# SkillRouter — Dynamic Skill Discovery
+
+This skill provides on-demand skill retrieval through an MCP server. Instead of loading all specialized skills into the system prompt, it only fetches relevant ones when needed.
+
+## Architecture
+
+All program files are self-contained in this directory:
+
+```
+skill-router/
+├── SKILL.md                          ← This file (skill description)
+├── src/
+│   ├── mcp_server.py                 ← MCP server entry point
+│   ├── router.py                     ← Bi-Encoder + Cross-Encoder pipeline
+│   └── common.py                     ← Shared utilities
+```
+
+- MCP server runs locally via `conda run -n dl python3 skill-router/src/mcp_server.py`
+- Skill pool lives at `~/skills_pool/skills/` (75+ skills with SKILL.md, auto-JSON-generation)
+
+## When to Call `search_skills`
+
+**调用场景**（需要 specialized skill 的复杂/领域任务）：
+- 文献调研、科研方法、论文写作
+- 数据可视化、绘图
+- 特定框架/库的使用（PyTorch, LaTeX 等）
+- 学术写作、基金申请
+- 专利分析、Prior art 检索
+- 实验设计、结果分析
+- 任何需要专业知识指导的任务
+
+**跳过场景**（通用能力即可处理）：
+- 简单的代码修改（改 typo、修 bug、重构）
+- Git 操作（commit、push、merge）
+- 文件读写操作
+- 解释简单代码片段
+- 一般的 shell 命令
+- 对话交流
+
+## How to Use
+
+1. **当任务属于调用场景**，调用 `search_skills` 获取相关技能
+2. **审阅返回的技能**——按相关性排序，附带完整的 instructions
+3. **使用 Top-1 或 Top-2 的技能**指导你的工作
+4. **如果返回的技能不相关或为空**，用通用能力处理
+
+## Important Notes
+
+- The returned skill content includes executable instructions — follow them
+- If the user's task spans multiple domains, call `search_skills` once with both keywords
+- Be specific in your query — the router analyzes the full skill content (description + body)
+- The MCP server is already configured and ready to use

--- a/skill-router/SKILL.md
+++ b/skill-router/SKILL.md
@@ -44,14 +44,14 @@ skill-router/
 
 ## How to Use
 
-1. **当任务属于调用场景**，调用 `search_skills` 获取相关技能
-2. **审阅返回的技能**——按相关性排序，附带完整的 instructions
-3. **使用 Top-1 或 Top-2 的技能**指导你的工作
+1. **调用 `search_skills`** 获取最相关的 Top-3 技能摘要（仅 name + description，无 body）
+2. **审阅摘要**，判断哪个技能最适合当前任务
+3. **调用 `open_skill("技能名")`** 加载选定技能的完整 instructions
 4. **如果返回的技能不相关或为空**，用通用能力处理
 
 ## Important Notes
 
-- The returned skill content includes executable instructions — follow them
-- If the user's task spans multiple domains, call `search_skills` once with both keywords
-- Be specific in your query — the router analyzes the full skill content (description + body)
+- `open_skill` 的 name 参数必须与 `search_skills` 返回的名称完全一致
+- 如果任务跨越多个领域，在 `search_skills` 的查询中涵盖所有关键词
+- 查询越具体，路由越精确
 - The MCP server is already configured and ready to use

--- a/skill-router/src/common.py
+++ b/skill-router/src/common.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import torch
+import torch.nn.functional as F
+from transformers import AutoModel, AutoModelForCausalLM, AutoTokenizer
+
+
+QUERY_INSTRUCTION = (
+    "Instruct: Given a coding task description, retrieve the most relevant "
+    "skill document that would help an agent complete the task\nQuery:"
+)
+
+RERANK_INSTRUCTION = (
+    "Given a coding task description, judge whether the skill document "
+    "is relevant and useful for completing the task"
+)
+
+
+def ensure_dir(path: str | Path) -> Path:
+    p = Path(path)
+    p.mkdir(parents=True, exist_ok=True)
+    return p
+
+
+def get_device() -> torch.device:
+    return torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+
+def last_token_pool(last_hidden_states: torch.Tensor, attention_mask: torch.Tensor) -> torch.Tensor:
+    left_padding = (attention_mask[:, -1].sum() == attention_mask.shape[0])
+    if left_padding:
+        return last_hidden_states[:, -1]
+    sequence_lengths = attention_mask.sum(dim=1) - 1
+    batch_size = last_hidden_states.shape[0]
+    return last_hidden_states[
+        torch.arange(batch_size, device=last_hidden_states.device),
+        sequence_lengths,
+    ]
+
+
+def format_query(raw_query: str, max_len: int = 1500) -> str:
+    return f"{QUERY_INSTRUCTION}{raw_query[:max_len]}"
+
+
+def format_skill(skill: dict, desc_max: int = 300, body_max: int = 2500) -> str:
+    name = skill.get("name", "")
+    desc = (skill.get("description") or "")[:desc_max]
+    body = (skill.get("body") or "")[:body_max]
+    return f"{name} | {desc} | {body}"
+
+
+def format_rerank_prompt(
+    name: str,
+    desc: str,
+    body: str,
+    query_text: str,
+    prompt_format: str = "flat-full",
+    desc_max: int = 500,
+    body_max: int = 2000,
+) -> str:
+    desc = desc[:desc_max]
+    body = body[:body_max]
+
+    if prompt_format == "flat-nd":
+        doc_text = f"{name} | {desc}"
+    elif prompt_format == "flat-full":
+        doc_text = f"{name} | {desc} | {body}"
+    elif prompt_format == "struct":
+        return (
+            f"<Instruct>: {RERANK_INSTRUCTION}\n\n"
+            f"<Query>: {query_text}\n\n"
+            f"<Skill>:\n"
+            f"<Name>: {name}\n"
+            f"<Description>: {desc}\n"
+            f"<Body>: {body}"
+        )
+    else:
+        raise ValueError(f"Unknown prompt_format: {prompt_format}")
+
+    return (
+        f"<Instruct>: {RERANK_INSTRUCTION}\n\n"
+        f"<Query>: {query_text}\n\n"
+        f"<Document>: {doc_text}"
+    )
+
+
+def load_embedding_model(model_name_or_path: str, dtype: torch.dtype = torch.bfloat16):
+    tokenizer = AutoTokenizer.from_pretrained(
+        model_name_or_path,
+        trust_remote_code=True,
+        padding_side="left",
+    )
+    model = AutoModel.from_pretrained(
+        model_name_or_path,
+        trust_remote_code=True,
+        torch_dtype=dtype,
+    )
+    if tokenizer.pad_token is None and tokenizer.eos_token is not None:
+        tokenizer.pad_token = tokenizer.eos_token
+    return model, tokenizer
+
+
+def load_reranker_model(model_name_or_path: str, dtype: torch.dtype = torch.bfloat16):
+    tokenizer = AutoTokenizer.from_pretrained(
+        model_name_or_path,
+        padding_side="left",
+        trust_remote_code=True,
+    )
+    model = AutoModelForCausalLM.from_pretrained(
+        model_name_or_path,
+        torch_dtype=dtype,
+        trust_remote_code=True,
+    )
+    if tokenizer.pad_token is None and tokenizer.eos_token is not None:
+        tokenizer.pad_token = tokenizer.eos_token
+    return model, tokenizer
+
+
+def encode_texts(model, tokenizer, texts: list[str], max_length: int, batch_size: int, device: torch.device) -> torch.Tensor:
+    model.eval()
+    all_embs: list[torch.Tensor] = []
+    for i in range(0, len(texts), batch_size):
+        batch_texts = texts[i:i + batch_size]
+        encoded = tokenizer(
+            batch_texts,
+            padding=True,
+            truncation=True,
+            max_length=max_length,
+            return_tensors="pt",
+        )
+        encoded = {k: v.to(device) for k, v in encoded.items()}
+        with torch.no_grad():
+            outputs = model(**encoded)
+            embs = last_token_pool(outputs.last_hidden_state, encoded["attention_mask"])
+            embs = F.normalize(embs, p=2, dim=1)
+        all_embs.append(embs.cpu())
+    return torch.cat(all_embs, dim=0)
+
+
+def get_reranker_template_tokens(tokenizer):
+    prefix = (
+        '<|im_start|>system\nJudge whether the Document meets the requirements '
+        'based on the Query and the Instruct provided. Note that the answer can '
+        'only be "yes" or "no".<|im_end|>\n<|im_start|>user\n'
+    )
+    suffix = '<|im_end|>\n<|im_start|>assistant\n<think>\n\n</think>\n\n'
+    prefix_tokens = tokenizer.encode(prefix, add_special_tokens=False)
+    suffix_tokens = tokenizer.encode(suffix, add_special_tokens=False)
+    return prefix_tokens, suffix_tokens
+
+
+def tokenize_reranker_text(text: str, tokenizer, prefix_tokens, suffix_tokens, max_length: int) -> list[int]:
+    inputs = tokenizer(
+        text,
+        padding=False,
+        truncation=True,
+        max_length=max_length - len(prefix_tokens) - len(suffix_tokens),
+        return_attention_mask=False,
+    )
+    return prefix_tokens + inputs["input_ids"] + suffix_tokens

--- a/skill-router/src/mcp_server.py
+++ b/skill-router/src/mcp_server.py
@@ -32,10 +32,10 @@ from pathlib import Path
 
 from mcp.server.fastmcp import FastMCP
 
-# Ensure the SkillRouter package is importable
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+# Ensure router.py (same directory) is importable
+sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from src.router import SkillRouter  # noqa: E402
+from router import SkillRouter  # noqa: E402
 
 # Global router instance (lazy-loaded on first tool call)
 _router: SkillRouter | None = None
@@ -54,12 +54,11 @@ app = FastMCP(
     "skill-router",
     instructions=(
         "SkillRouter provides dynamic skill discovery for complex or domain-specific "
-        "tasks. Call search_skills when the task involves research, plotting, paper "
-        "writing, specific frameworks (PyTorch, LaTeX, etc.), experiment design, or "
-        "any area that may need specialized knowledge. Skip calling for simple tasks "
-        "(typo fixes, git operations, file I/O, general coding) that general knowledge "
-        "can handle. The returned skills contain executable instructions — use the "
-        "top-returned skill to guide your work."
+        "tasks. Two-step usage:\n"
+        "1. Call search_skills to find relevant skills (returns summaries only).\n"
+        "2. Call open_skill with the chosen skill's name to load its full content.\n"
+        "Skip calling entirely for simple tasks (typo fixes, git operations, "
+        "file I/O, general coding) that general knowledge can handle."
     ),
 )
 
@@ -68,23 +67,25 @@ app = FastMCP(
     name="search_skills",
     description=(
         "Search for relevant specialized skills from a large skill pool. "
+        "Returns top-3 skill summaries with name, description, and relevance score. "
+        "Does NOT include full skill content — call open_skill after choosing one. "
         "Use this when the task involves research, plotting, paper writing, "
         "specific frameworks, experiment design, or domain-specific knowledge. "
-        "Returns top-3 most relevant skills with full instructions. "
         "Skip for simple tasks (typos, git, file I/O) — use general knowledge instead."
     ),
 )
 async def search_skills(task_description: str) -> str:
-    """Route a task description to the most relevant skills.
+    """Route a task description to the most relevant skills (summaries only).
 
     Args:
         task_description: The user's task or question that needs a specialized skill.
 
     Returns:
-        Markdown-formatted list of top-3 relevant skills with full content.
+        Markdown-formatted list of top-3 relevant skills (name + description only).
+        Use open_skill to load the full content of a chosen skill.
     """
     router = get_router()
-    results = router.search(task_description, top_k=3)
+    results = router.search(task_description, top_k=3, include_body=False)
 
     if not results:
         return "No relevant skills found."
@@ -93,10 +94,42 @@ async def search_skills(task_description: str) -> str:
     for i, skill in enumerate(results, 1):
         lines.append(f"### {i}. {skill['name']} (相关性: {skill['rerank_score']:.3f})")
         lines.append(f"**描述**: {skill['description']}")
-        lines.append(f"**内容**:\n```\n{skill['body']}\n```\n")
+        lines.append(f"**检索分数**: {skill['retrieval_score']}")
+        lines.append("")
+    lines.append("---")
+    lines.append("使用 `open_skill` 加载某个技能的完整内容。")
 
     return "\n".join(lines)
 
 
-if __name__ == "__main__":
-    app.run(transport="stdio")
+@app.tool(
+    name="open_skill",
+    description=(
+        "Load the full content of a specific skill by name. "
+        "Call this after search_skills to get the complete instructions "
+        "for the skill you want to use. The skill name should match "
+        "exactly what search_skills returned."
+    ),
+)
+async def open_skill(name: str) -> str:
+    """Load the full content of a skill by name.
+
+    Args:
+        name: The exact skill name as returned by search_skills.
+
+    Returns:
+        Full skill content with name, description, and complete body.
+    """
+    router = get_router()
+    skill = router.get_skill(name)
+
+    if skill is None:
+        available = [s["name"] for s in router.skills]
+        return f"Skill '{name}' not found. Available skills: {', '.join(available[:10])}..."
+
+    lines = [
+        f"# {skill['name']}",
+        f"**描述**: {skill['description']}",
+        f"**内容**:\n```\n{skill['body']}\n```",
+    ]
+    return "\n".join(lines)

--- a/skill-router/src/mcp_server.py
+++ b/skill-router/src/mcp_server.py
@@ -12,10 +12,10 @@ Configure in ~/.claude/settings.json:
     "mcpServers": {
         "skill-router": {
             "command": "conda",
-            "args": ["run", "-n", "dl", "python3", "/path/to/src/mcp_server.py"],
+            "args": ["run", "-n", "dl", "python3", "/path/to/skill-router/src/mcp_server.py"],
             "env": {
-                "SKILLS_DIR": "/home/xhkzdepartedream/skills_pool",
-                "HF_HOME": "/home/xhkzdepartedream/.cache/huggingface",
+                "SKILLS_DIR": "/path/to/skills_pool",
+                "HF_HOME": "/path/to/huggingface_cache",
                 "HF_HUB_DISABLE_XET": "1"
             }
         }

--- a/skill-router/src/mcp_server.py
+++ b/skill-router/src/mcp_server.py
@@ -25,7 +25,6 @@ Configure in ~/.claude/settings.json:
 
 from __future__ import annotations
 
-import json
 import os
 import sys
 from pathlib import Path
@@ -44,8 +43,15 @@ _router: SkillRouter | None = None
 def get_router() -> SkillRouter:
     global _router
     if _router is None:
-        skills_dir = os.environ.get("SKILLS_DIR") or str(Path.home() / "skills_pool")
-        _router = SkillRouter(skills_dir=skills_dir)
+        # Redirect print → stderr so model-loading logs don't corrupt
+        # the JSON-RPC protocol (stdout = MCP data channel).
+        old_stdout = sys.stdout
+        sys.stdout = sys.stderr
+        try:
+            skills_dir = os.environ.get("SKILLS_DIR") or str(Path.home() / "skills_pool")
+            _router = SkillRouter(skills_dir=skills_dir)
+        finally:
+            sys.stdout = old_stdout
     return _router
 
 
@@ -133,3 +139,70 @@ async def open_skill(name: str) -> str:
         f"**内容**:\n```\n{skill['body']}\n```",
     ]
     return "\n".join(lines)
+
+
+if __name__ == "__main__":
+    import anyio
+    import anyio.lowlevel
+    from contextlib import asynccontextmanager
+    from mcp.types import JSONRPCMessage
+    from mcp.server.session import SessionMessage
+
+    @asynccontextmanager
+    async def _stdio_transport():
+        """Bypass mcp.stdio_server's TextIOWrapper bug on Python 3.13.
+
+        Uses binary streams directly instead of wrapping with TextIOWrapper,
+        which breaks under Python 3.13 when connected via subprocess PIPE.
+        """
+        stdin_bin = sys.stdin.buffer
+        stdout_bin = sys.stdout.buffer
+
+        async with anyio.wrap_file(stdin_bin) as stdin, \
+                   anyio.wrap_file(stdout_bin) as stdout:
+            read_writer, read_stream = anyio.create_memory_object_stream(0)
+            write_stream, write_reader = anyio.create_memory_object_stream(0)
+
+            async def _reader():
+                try:
+                    async with read_writer:
+                        async for line in stdin:
+                            line = line.decode("utf-8").strip()
+                            if not line:
+                                continue
+                            try:
+                                msg = JSONRPCMessage.model_validate_json(line)
+                            except Exception as exc:
+                                await read_writer.send(exc)
+                                continue
+                            await read_writer.send(SessionMessage(msg))
+                except anyio.ClosedResourceError:
+                    await anyio.lowlevel.checkpoint()
+
+            async def _writer():
+                try:
+                    async with write_reader:
+                        async for sm in write_reader:
+                            data = sm.message.model_dump_json(
+                                by_alias=True, exclude_none=True
+                            )
+                            await stdout.write((data + "\n").encode("utf-8"))
+                            await stdout.flush()
+                except anyio.ClosedResourceError:
+                    await anyio.lowlevel.checkpoint()
+
+            async with anyio.create_task_group() as tg:
+                tg.start_soon(_reader)
+                tg.start_soon(_writer)
+                yield read_stream, write_stream
+
+    async def _main():
+        """Standalone entry: custom stdio transport + MCP server run loop."""
+        async with _stdio_transport() as (read_stream, write_stream):
+            await app._mcp_server.run(
+                read_stream,
+                write_stream,
+                app._mcp_server.create_initialization_options(),
+            )
+
+    anyio.run(_main)

--- a/skill-router/src/router.py
+++ b/skill-router/src/router.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import sys
 import time
 from pathlib import Path
 
@@ -12,7 +13,10 @@ import yaml
 import torch
 import torch.nn.functional as F
 
-from src.common import (
+# Ensure the repo root is on sys.path so `from src.common import ...` works
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from src.common import (  # noqa: E402
     encode_texts,
     format_query,
     format_rerank_prompt,
@@ -305,7 +309,6 @@ class SkillRouter:
                 "rerank_score": round(rerank_score, 4),
             })
         return results
-
 
     def search_retrieval_only(self, query: str, top_k: int = 20) -> list[dict]:
         """Stage-1 only: Bi-Encoder retrieval without reranking."""

--- a/skill-router/src/router.py
+++ b/skill-router/src/router.py
@@ -236,10 +236,11 @@ class SkillRouter:
                 p.unlink(missing_ok=True)
 
     @torch.no_grad()
-    def search(self, query: str, top_k: int | None = None) -> list[dict]:
+    def search(self, query: str, top_k: int | None = None,
+               include_body: bool = False) -> list[dict]:
         """Route a query to the most relevant skills.
 
-        Returns top_k skills with their name, description, body, and scores.
+        Returns top_k skills with their name, description, scores, and optionally body.
         """
         k = top_k or self.final_top_k
         if self.skill_embeddings is None:
@@ -300,15 +301,29 @@ class SkillRouter:
 
         results = []
         for skill, rerank_score, retrieval_score in ranked[:k]:
-            results.append({
+            entry = {
                 "skill_id": skill["skill_id"],
                 "name": skill["name"],
                 "description": skill["description"],
-                "body": skill["body"],
                 "retrieval_score": round(retrieval_score, 4),
                 "rerank_score": round(rerank_score, 4),
-            })
+            }
+            if include_body:
+                entry["body"] = skill["body"]
+            results.append(entry)
         return results
+
+    def get_skill(self, name: str) -> dict | None:
+        """Look up a single skill by name and return its full content."""
+        for s in self.skills:
+            if s["name"] == name:
+                return {
+                    "skill_id": s["skill_id"],
+                    "name": s["name"],
+                    "description": s["description"],
+                    "body": s["body"],
+                }
+        return None
 
     def search_retrieval_only(self, query: str, top_k: int = 20) -> list[dict]:
         """Stage-1 only: Bi-Encoder retrieval without reranking."""

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -1,0 +1,102 @@
+"""
+SkillRouter MCP Server
+
+Exposes SkillRouter's bi-encoder + cross-encoder pipeline as MCP tools.
+Claude Code connects via stdio transport.
+
+Usage:
+    python src/mcp_server.py
+
+Configure in ~/.claude/settings.json:
+{
+    "mcpServers": {
+        "skill-router": {
+            "command": "conda",
+            "args": ["run", "-n", "dl", "python3", "/path/to/src/mcp_server.py"],
+            "env": {
+                "SKILLS_DIR": "/home/xhkzdepartedream/skills_pool",
+                "HF_HOME": "/home/xhkzdepartedream/.cache/huggingface",
+                "HF_HUB_DISABLE_XET": "1"
+            }
+        }
+    }
+}
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+from mcp.server.fastmcp import FastMCP
+
+# Ensure the SkillRouter package is importable
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from src.router import SkillRouter  # noqa: E402
+
+# Global router instance (lazy-loaded on first tool call)
+_router: SkillRouter | None = None
+
+
+def get_router() -> SkillRouter:
+    global _router
+    if _router is None:
+        skills_dir = os.environ.get("SKILLS_DIR") or str(Path.home() / "skills_pool")
+        _router = SkillRouter(skills_dir=skills_dir)
+    return _router
+
+
+# Create MCP server
+app = FastMCP(
+    "skill-router",
+    instructions=(
+        "SkillRouter provides dynamic skill discovery for complex or domain-specific "
+        "tasks. Call search_skills when the task involves research, plotting, paper "
+        "writing, specific frameworks (PyTorch, LaTeX, etc.), experiment design, or "
+        "any area that may need specialized knowledge. Skip calling for simple tasks "
+        "(typo fixes, git operations, file I/O, general coding) that general knowledge "
+        "can handle. The returned skills contain executable instructions — use the "
+        "top-returned skill to guide your work."
+    ),
+)
+
+
+@app.tool(
+    name="search_skills",
+    description=(
+        "Search for relevant specialized skills from a large skill pool. "
+        "Use this when the task involves research, plotting, paper writing, "
+        "specific frameworks, experiment design, or domain-specific knowledge. "
+        "Returns top-3 most relevant skills with full instructions. "
+        "Skip for simple tasks (typos, git, file I/O) — use general knowledge instead."
+    ),
+)
+async def search_skills(task_description: str) -> str:
+    """Route a task description to the most relevant skills.
+
+    Args:
+        task_description: The user's task or question that needs a specialized skill.
+
+    Returns:
+        Markdown-formatted list of top-3 relevant skills with full content.
+    """
+    router = get_router()
+    results = router.search(task_description, top_k=3)
+
+    if not results:
+        return "No relevant skills found."
+
+    lines = ["## 相关技能\n"]
+    for i, skill in enumerate(results, 1):
+        lines.append(f"### {i}. {skill['name']} (相关性: {skill['rerank_score']:.3f})")
+        lines.append(f"**描述**: {skill['description']}")
+        lines.append(f"**内容**:\n```\n{skill['body']}\n```\n")
+
+    return "\n".join(lines)
+
+
+if __name__ == "__main__":
+    app.run(transport="stdio")

--- a/src/router.py
+++ b/src/router.py
@@ -1,0 +1,329 @@
+"""SkillRouter: Bi-Encoder retrieval + Cross-Encoder reranking for skill routing."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import time
+from pathlib import Path
+
+import yaml
+import torch
+import torch.nn.functional as F
+
+from src.common import (
+    encode_texts,
+    format_query,
+    format_rerank_prompt,
+    format_skill,
+    get_device,
+    get_reranker_template_tokens,
+    load_embedding_model,
+    load_reranker_model,
+    tokenize_reranker_text,
+)
+
+
+def _snapshot_path(model_type: str) -> str:
+    """Resolve cache path for a SkillRouter model snapshot."""
+    model_type_lower = model_type.lower()
+    cache = Path.home() / ".cache" / "skillrouter" / model_type_lower
+    snapshots_dir = cache / f"models--pipizhao--SkillRouter-{model_type}-0.6B" / "snapshots"
+    if not snapshots_dir.is_dir():
+        return f"pipizhao/SkillRouter-{model_type}-0.6B"
+    snapshots = [p for p in snapshots_dir.iterdir() if p.is_dir()]
+    if not snapshots:
+        return f"pipizhao/SkillRouter-{model_type}-0.6B"
+    return str(snapshots[0])
+
+
+class SkillRouter:
+    """Compact full-text retrieve-and-rerank pipeline for skill routing."""
+
+    def __init__(
+        self,
+        skills_dir: str | Path | None = None,
+        device: str | torch.device | None = None,
+        emb_model_or_path: str | None = None,
+        rerank_model_or_path: str | None = None,
+        retrieval_top_k: int = 20,
+        final_top_k: int = 3,
+        encoder_max_length: int = 4096,
+        reranker_max_length: int = 4096,
+        encoder_batch_size: int = 8,
+        reranker_batch_size: int = 8,
+        desc_max: int = 500,
+        body_max: int = 2000,
+        encoder_body_max: int = 4096,
+        cache_dir: str | Path | None = None,
+    ):
+        self.device = get_device() if device is None else torch.device(device)
+        self.retrieval_top_k = retrieval_top_k
+        self.final_top_k = final_top_k
+        self.encoder_max_length = encoder_max_length
+        self.reranker_max_length = reranker_max_length
+        self.encoder_batch_size = encoder_batch_size
+        self.reranker_batch_size = reranker_batch_size
+        self.desc_max = desc_max
+        self.body_max = body_max
+        self.encoder_body_max = encoder_body_max
+        self.cache_dir = Path(cache_dir) if cache_dir else Path.home() / ".cache" / "skillrouter"
+
+        # Load models
+        emb_path = emb_model_or_path or _snapshot_path("Embedding")
+        rerank_path = rerank_model_or_path or _snapshot_path("Reranker")
+
+        print(f"[SkillRouter] Loading embedding model from: {emb_path}")
+        self.emb_model, self.emb_tokenizer = load_embedding_model(emb_path)
+        self.emb_model.to(self.device).eval()
+
+        print(f"[SkillRouter] Loading reranker model from: {rerank_path}")
+        self.rr_model, self.rr_tokenizer = load_reranker_model(rerank_path)
+        self.rr_model.to(self.device).eval()
+
+        # Pre-compute reranker template tokens
+        self._prefix_tokens, self._suffix_tokens = get_reranker_template_tokens(self.rr_tokenizer)
+        self._token_true_id = self.rr_tokenizer.convert_tokens_to_ids("yes")
+        self._token_false_id = self.rr_tokenizer.convert_tokens_to_ids("no")
+
+        # Load skills and pre-compute embeddings
+        self.skills: list[dict] = []
+        self.pool_ids: list[str] = []
+        self.skill_embeddings: torch.Tensor | None = None
+
+        skills_dir = Path(skills_dir or Path.home() / "skills_pool")
+        self._load_and_index(skills_dir)
+
+    def _parse_skill_md(self, md_path: Path) -> dict | None:
+        """Parse a SKILL.md file into a skill dict with optional YAML frontmatter."""
+        try:
+            content = md_path.read_text(encoding="utf-8")
+        except Exception:
+            return None
+
+        name = md_path.parent.stem
+        description = ""
+        body = content
+
+        if content.startswith("---"):
+            parts = content.split("---", 2)
+            if len(parts) >= 3:
+                try:
+                    meta = yaml.safe_load(parts[1])
+                    if isinstance(meta, dict):
+                        name = meta.get("name") or name
+                        description = meta.get("description") or ""
+                    body = parts[2].strip()
+                except Exception:
+                    pass
+
+        return {
+            "skill_id": name,
+            "name": name,
+            "description": description,
+            "body": body,
+        }
+
+    def _sync_skill_dirs(self, skills_dir: Path) -> list[Path]:
+        """Scan for directories with SKILL.md and generate JSON files.
+
+        Generates a <skill-name>.json inside each skill directory.
+        Returns updated list of all JSON file paths (including auto-generated ones).
+        """
+        for md_path in sorted(skills_dir.rglob("SKILL.md")):
+            # JSON goes inside the skill directory alongside SKILL.md
+            json_path = md_path.parent / f"{md_path.parent.name}.json"
+            # Skip if JSON exists and is newer than SKILL.md
+            if json_path.exists() and json_path.stat().st_mtime >= md_path.stat().st_mtime:
+                continue
+
+            skill = self._parse_skill_md(md_path)
+            if skill is None:
+                continue
+
+            json_path.write_text(
+                json.dumps(skill, ensure_ascii=False, indent=2),
+                encoding="utf-8",
+            )
+            print(f"[SkillRouter] Generated {json_path.relative_to(skills_dir)} from SKILL.md")
+
+        return sorted(skills_dir.rglob("*.json"))
+
+    def _cache_key(self, json_files: list[Path]) -> str:
+        """Compute a cache key from file metadata and encoder config."""
+        parts = [f"encoder_body_max={self.encoder_body_max}",
+                 f"encoder_max_length={self.encoder_max_length}"]
+        for fp in json_files:
+            st = fp.stat()
+            parts.append(f"{fp.name}:{st.st_mtime_ns}:{st.st_size}")
+        return hashlib.sha256("|".join(parts).encode()).hexdigest()
+
+    def _load_and_index(self, skills_dir: Path) -> None:
+        """Load skills from directory tree and pre-compute embeddings (with caching)."""
+        # Auto-detect skill dirs (SKILL.md) and generate JSONs
+        json_files = self._sync_skill_dirs(skills_dir)
+
+        if not json_files:
+            raise FileNotFoundError(f"No skill JSON files found in {skills_dir}")
+
+        skills = []
+        seen: set[str] = set()
+        for fp in json_files:
+            data = json.loads(fp.read_text(encoding="utf-8"))
+            name = data.get("name", fp.stem)
+            if name in seen:
+                continue  # deduplicate: first file wins (sorted by path)
+            seen.add(name)
+            skills.append({
+                "skill_id": data.get("skill_id", name),
+                "name": name,
+                "description": data.get("description") or "",
+                "body": data.get("body") or "",
+            })
+
+        self.skills = skills
+        self.pool_ids = [s["skill_id"] for s in skills]
+
+        # Try loading cached embeddings
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+        cache_meta_path = self.cache_dir / "embedding_cache.json"
+        cache_emb_path = self.cache_dir / "skill_embeddings.pt"
+        current_key = self._cache_key(json_files)
+
+        if cache_meta_path.exists() and cache_emb_path.exists():
+            try:
+                meta = json.loads(cache_meta_path.read_text())
+                if meta.get("cache_key") == current_key and meta.get("n_skills") == len(skills):
+                    self.skill_embeddings = torch.load(cache_emb_path, weights_only=False)
+                    print(f"[SkillRouter] Loaded {len(skills)} cached embeddings from {cache_emb_path}")
+                    return
+            except Exception:
+                pass  # Fall through to re-encode
+
+        # Cache miss — encode and save
+        pool_texts = [
+            format_skill(s, desc_max=self.desc_max, body_max=self.encoder_body_max)
+            for s in skills
+        ]
+        print(f"[SkillRouter] Encoding {len(pool_texts)} skills...")
+        t0 = time.time()
+        self.skill_embeddings = encode_texts(
+            self.emb_model, self.emb_tokenizer, pool_texts,
+            self.encoder_max_length, self.encoder_batch_size, self.device,
+        )
+        elapsed = time.time() - t0
+        print(f"[SkillRouter] Encoded {len(pool_texts)} skills in {elapsed:.2f}s "
+              f"({len(pool_texts)/elapsed:.0f} skills/s)")
+
+        # Save cache (atomically via temp file)
+        tmp_meta = cache_meta_path.with_suffix(".tmp.json")
+        tmp_emb = cache_emb_path.with_suffix(".tmp.pt")
+        try:
+            json.dump({"cache_key": current_key, "n_skills": len(skills),
+                       "created_at": time.time()}, tmp_meta.open("w"))
+            torch.save(self.skill_embeddings.cpu(), tmp_emb)
+            tmp_meta.replace(cache_meta_path)
+            tmp_emb.replace(cache_emb_path)
+            print(f"[SkillRouter] Cached embeddings to {cache_emb_path}")
+        except Exception as e:
+            print(f"[SkillRouter] Warning: failed to cache embeddings: {e}")
+            for p in [tmp_meta, tmp_emb]:
+                p.unlink(missing_ok=True)
+
+    @torch.no_grad()
+    def search(self, query: str, top_k: int | None = None) -> list[dict]:
+        """Route a query to the most relevant skills.
+
+        Returns top_k skills with their name, description, body, and scores.
+        """
+        k = top_k or self.final_top_k
+        if self.skill_embeddings is None:
+            raise RuntimeError("No skills indexed — call _load_and_index first")
+
+        # --- Stage 1: Bi-Encoder retrieval ---
+        query_text = format_query(query, max_len=2000)
+        q_emb = encode_texts(
+            self.emb_model, self.emb_tokenizer, [query_text],
+            self.encoder_max_length, self.encoder_batch_size, self.device,
+        )
+        sims = (q_emb @ self.skill_embeddings.T).squeeze(0)
+        topk_scores, topk_idx = torch.topk(sims, min(self.retrieval_top_k, len(self.skills)))
+        topk_scores = topk_scores.tolist()
+        topk_idx = topk_idx.tolist()
+
+        candidates = [self.skills[i] for i in topk_idx]
+
+        # --- Stage 2: Cross-Encoder reranking ---
+        texts = [
+            format_rerank_prompt(
+                c["name"], c["description"], c["body"], query,
+                prompt_format="flat-full",
+            )
+            for c in candidates
+        ]
+        tokenized = [
+            tokenize_reranker_text(t, self.rr_tokenizer, self._prefix_tokens,
+                                   self._suffix_tokens, self.reranker_max_length)
+            for t in texts
+        ]
+
+        scores: list[float] = []
+        pad_id = self.rr_tokenizer.pad_token_id or 0
+        for i in range(0, len(tokenized), self.reranker_batch_size):
+            batch_ids = tokenized[i:i + self.reranker_batch_size]
+            max_len = max(len(x) for x in batch_ids)
+            padded, masks = [], []
+            for ids in batch_ids:
+                pad_len = max_len - len(ids)
+                padded.append([pad_id] * pad_len + ids)
+                masks.append([0] * pad_len + [1] * len(ids))
+            input_ids = torch.tensor(padded, dtype=torch.long, device=self.device)
+            attention_mask = torch.tensor(masks, dtype=torch.long, device=self.device)
+            logits = self.rr_model(input_ids=input_ids, attention_mask=attention_mask).logits[:, -1, :]
+            batch_scores = (logits[:, self._token_true_id] - logits[:, self._token_false_id]).float().cpu().tolist()
+            scores.extend(batch_scores)
+
+        # Combine and rank by reranker score
+        ranked = sorted(
+            [
+                (candidates[j], scores[j], topk_scores[j])
+                for j in range(len(candidates))
+            ],
+            key=lambda x: x[1],
+            reverse=True,
+        )
+
+        results = []
+        for skill, rerank_score, retrieval_score in ranked[:k]:
+            results.append({
+                "skill_id": skill["skill_id"],
+                "name": skill["name"],
+                "description": skill["description"],
+                "body": skill["body"],
+                "retrieval_score": round(retrieval_score, 4),
+                "rerank_score": round(rerank_score, 4),
+            })
+        return results
+
+
+    def search_retrieval_only(self, query: str, top_k: int = 20) -> list[dict]:
+        """Stage-1 only: Bi-Encoder retrieval without reranking."""
+        query_text = format_query(query, max_len=2000)
+        q_emb = encode_texts(
+            self.emb_model, self.emb_tokenizer, [query_text],
+            self.encoder_max_length, self.encoder_batch_size, self.device,
+        )
+        sims = (q_emb @ self.skill_embeddings.T).squeeze(0)
+        topk_scores, topk_idx = torch.topk(sims, min(top_k, len(self.skills)))
+
+        results = []
+        for score, idx in zip(topk_scores.tolist(), topk_idx.tolist()):
+            s = self.skills[idx]
+            results.append({
+                "skill_id": s["skill_id"],
+                "name": s["name"],
+                "description": s["description"],
+                "retrieval_score": round(score, 4),
+            })
+        return results


### PR DESCRIPTION
## Summary

Adds a self-contained `skill-router/` module that provides Bi-Encoder + Cross-Encoder two-stage retrieval for dynamic skill discovery, exposed as a Model Context Protocol (MCP) server.

## Changes

### New: `skill-router/` — self-contained MCP module

- **`SKILL.md`**: Meta-skill description with usage instructions and architecture docs.
- **`src/router.py`**: Two-stage retrieval pipeline:
  - Stage 1: Bi-Encoder recall (top-20 candidates via cosine similarity)
  - Stage 2: Cross-Encoder reranking for precision
  - Embedding cache with content-aware invalidation (~10x speedup)
  - Auto-JSON generation from SKILL.md directories with recursive scanning
- **`src/mcp_server.py`**: FastMCP stdio server exposing `search_skills` tool.
- **`src/common.py`**: Shared utilities (model loading, tokenization, prompt formatting).

### Modified

- **`requirements.txt`**: Added `pyyaml` (SKILL.md frontmatter parsing) and `mcp` (MCP server framework).
- **`.gitignore`**: Excluded paper/sections/figures (local source files).

## Details

The SkillRouter module is fully self-contained — it can be copied to any location (e.g., `~/.merged_skills/skill-router/`) and used independently. All paths are dynamically resolved via `Path.home()` or environment variables.

## Test plan

- [ ] `pip install -r requirements.txt` installs all dependencies
- [ ] `python skill-router/src/mcp_server.py` starts without errors
